### PR TITLE
Support untilBuild 210.*

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # BitBake IntelliJ Plugin
 
+
+## Build Using Official Gradle Container
+
+This mounts the current directory into the container, so a `.gradle` cache will be created for quick reruns.
+
+    docker run --rm -it -u gradle -v "$PWD":/home/gradle/project -w /home/gradle/project gradle:latest gradle buildPlugin

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,10 @@ sourceSets.main.java.srcDirs 'src/main/gen'
 intellij {
     version '2020.1.3'
     pluginName 'BitBake'
+    patchPluginXml {
+        sinceBuild '201.0'
+        untilBuild '210.*'
+    }
 }
 
 patchPluginXml {


### PR DESCRIPTION
Hi @vitalibo 

Great to finally see a yocto/bitbake plugin!

I'm not a Intellij/Java expert, but this PR permits opportunistic install up to version 2030.* per [here](https://jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html)

Feel free to constrain it more conservativly if you add it to marketplace, perhaps make this a unsupported build arg for EAP users like myself.